### PR TITLE
docs(answers): fix typo in API route

### DIFF
--- a/docs/answers/GETANSWERS.MD
+++ b/docs/answers/GETANSWERS.MD
@@ -2,7 +2,7 @@
 
 ```yaml
 # GET
-https://www.codegrepper.com/get_answers_1.php
+https://www.codegrepper.com/api/get_answers_1.php
 ```
 
 ```js


### PR DESCRIPTION
Noticed that I was copying the URL from this line and that's why I was getting a 404. 

